### PR TITLE
Add Rust implementation

### DIFF
--- a/parens.rs
+++ b/parens.rs
@@ -1,0 +1,36 @@
+use std::env;
+use std::str;
+
+static mut SIZE: usize = 0;
+static mut STACK: [u8; 64] = [0x0; 64];
+
+unsafe fn _parens(left: usize, right: usize) {
+    if left == 0 && right == 0 {
+        println!("{}", str::from_utf8(&STACK).unwrap());
+    }
+
+    if left > 0 {
+        STACK[SIZE - left - right] = b'(';
+        _parens(left - 1, right);
+    }
+
+    if right > left {
+        STACK[SIZE - left - right] = b')';
+        _parens(left, right - 1);
+    }
+}
+
+fn parens(n: usize) {
+    unsafe {
+        SIZE = 2 * n;
+        if STACK.len() < SIZE {
+            panic!();
+        }
+        _parens(n, n);
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    parens(args[1].parse::<usize>().unwrap());
+}

--- a/parens.rs
+++ b/parens.rs
@@ -1,36 +1,25 @@
 use std::env;
 use std::str;
 
-static mut SIZE: usize = 0;
-static mut STACK: [u8; 64] = [0x0; 64];
-
-unsafe fn _parens(left: usize, right: usize) {
+fn _parens(prefix: String, left: i32, right: i32) {
     if left == 0 && right == 0 {
-        println!("{}", str::from_utf8(&STACK).unwrap());
+        println!("{}", prefix);
     }
 
     if left > 0 {
-        STACK[SIZE - left - right] = b'(';
-        _parens(left - 1, right);
+        _parens(prefix.clone() + "(", left - 1, right);
     }
 
     if right > left {
-        STACK[SIZE - left - right] = b')';
-        _parens(left, right - 1);
+        _parens(prefix.clone() + ")", left, right - 1);
     }
 }
 
-fn parens(n: usize) {
-    unsafe {
-        SIZE = 2 * n;
-        if STACK.len() < SIZE {
-            panic!();
-        }
-        _parens(n, n);
-    }
+fn parens(n: i32) {
+    _parens("".to_string(), n, n);
 }
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    parens(args[1].parse::<usize>().unwrap());
+    parens(args[1].parse::<i32>().unwrap());
 }

--- a/parens.rs
+++ b/parens.rs
@@ -1,17 +1,26 @@
 use std::env;
 use std::str;
 
+macro_rules! concat_string {
+    ($a: expr, $b: expr) => {{
+        let mut s = String::with_capacity(64);
+        s.push_str($a);
+        s.push_str($b);
+        s
+    }};
+}
+
 fn _parens(prefix: String, left: i32, right: i32) {
     if left == 0 && right == 0 {
         println!("{}", prefix);
     }
 
     if left > 0 {
-        _parens(prefix.clone() + "(", left - 1, right);
+        _parens(concat_string!(&prefix, "("), left - 1, right);
     }
 
     if right > left {
-        _parens(prefix.clone() + ")", left, right - 1);
+        _parens(concat_string!(&prefix, ")"), left, right - 1);
     }
 }
 


### PR DESCRIPTION
This is Rust port of C. It's slower than C about 9 times in my environment.
- C (clang -O3): 0.2 s
- Rust(port of C / 92f61add53fb2332de60dd143cf0b8480bd7039e): 1.86 s
- Rust(simple concat / 1b6ab68a2b34f324e8c33a52c81efb911d93c2be): 4.12 s
- Rust(String with capacity / 427643252c2499158f13309a0ebbcf94f7709d3d): 2.75 s
---
Compile option
- rustc -C opt-level=3 -C debug_assertions=no

--
Update 2017-07-06: Add two styles