### PR TITLE
Add Golang implementation

### DIFF
--- a/parens.go
+++ b/parens.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strconv"
+)
+
+func _parens(prefix string, left int, right int, w io.Writer) {
+	if left == 0 && right == 0 {
+		w.Write([]byte(prefix + "\n"))
+	}
+
+	if left > 0 {
+		_parens(prefix+"(", left-1, right, w)
+	}
+
+	if right > left {
+		_parens(prefix+")", left, right-1, w)
+	}
+}
+
+func parens(n int) {
+	stdout := bufio.NewWriter(os.Stdout)
+	_parens("", n, n, stdout)
+	stdout.Flush()
+}
+
+func main() {
+	i, _ := strconv.Atoi(os.Args[1])
+	parens(i)
+}


### PR DESCRIPTION
This PR introduces Golang implementation.

- C (clang -O3): 0.22 s
- Golang (go build parens.go): 1.53 s

I couldn't think that Go implementation is even faster than Rust... Rust code could be more tuning.

---
- clang version 4.0.0 (tags/RELEASE_400/final)
- go version go1.8.3 linux/amd64